### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/MySecondTestApp/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/MySecondTestApp/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1044,7 +1044,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.escapeCssMeta(element) ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/catalin-sbora/MySecondTestApp/security/code-scanning/3](https://github.com/catalin-sbora/MySecondTestApp/security/code-scanning/3)

To fix the problem, we need to ensure that all user inputs are properly sanitized before being used in jQuery selectors. Specifically, we should use the `escapeCssMeta` function to sanitize the `element` in the `validationTargetFor` function. This will prevent any potential XSS vulnerabilities by escaping any special characters that could be used in a malicious way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
